### PR TITLE
Addition of Windows support with preprocessing

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -11,6 +11,10 @@ auto-executables = true
 auto-examples = true
 auto-tests = true
 
+[preprocess]
+cpp.suffixes = ["F90", "f90"]
+# cpp.macros = ["_WIN32"]
+
 [library]
 source-dir = "src"
 

--- a/src/popen_module.f90
+++ b/src/popen_module.f90
@@ -13,7 +13,12 @@
     ! interfaces to C functions
     interface
 
-        function popen(command, mode) bind(C,name='popen')
+        function popen(command, mode) &
+#ifdef _WIN32
+            bind(C,name='_popen')
+#else
+            bind(C,name='popen')
+#endif
         !! initiate pipe streams to or from a process
         import :: c_char, c_ptr
         implicit none
@@ -22,7 +27,12 @@
         type(c_ptr) :: popen
         end function popen
 
-        function fgets(s, siz, stream) bind(C,name='fgets')
+        function fgets(s, siz, stream) &
+#ifdef _WIN32
+            bind(C,name='fgets')
+#else
+            bind(C,name='fgets')
+#endif
         !! get a string from a stream
         import :: c_char, c_ptr, c_int
         implicit none
@@ -32,7 +42,12 @@
         type(c_ptr),value :: stream
         end function fgets
 
-        function pclose(stream) bind(C,name='pclose')
+        function pclose(stream) &
+#ifdef _WIN32
+            bind(C,name='_pclose')
+#else
+            bind(C,name='pclose')
+#endif
         !! close a pipe stream to or from a process
         import :: c_ptr, c_int
         implicit none

--- a/test/test.f90
+++ b/test/test.f90
@@ -6,10 +6,20 @@ implicit none
 
 character(len=:),allocatable :: res
 
-res = get_command_as_string('uname')
+#ifdef _WIN32
+    res = get_command_as_string('ver')
+#else
+    res = get_command_as_string('uname')
+#endif
+
 write(*,'(A)') res
 
-res = get_command_as_string('ls -l')
+#ifdef _WIN32
+    res = get_command_as_string('dir')
+#else
+    res = get_command_as_string('ls -l')
+#endif
+
 write(*,'(A)') res
 
 end program test


### PR DESCRIPTION
I wanted to use such functionality on Windows, but as usual they did it differently. 
For once, it is not too different: `popen` became `_popen` and `pclose` became `_pclose`. 
The support is obtained via the preprocessor macro `_WIN32`.
```fortran 
  function popen(command, mode) &
#ifdef _WIN32
            bind(C,name='_popen')
#else
            bind(C,name='popen')
#endif
```
I also updated the toml 
```toml
[preprocess]
cpp.suffixes = ["F90", "f90"]
# cpp.macros = ["_WIN32"]
```
The only thing to do is to uncomment the cpp.macros. 

I also updated the test case because `uname` and `ls` do not exist on windows